### PR TITLE
add package scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "subscribed-hypercored",
-  "version": "1.4.1-pre.1",
+  "version": "1.4.1-pre.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,13 +9,14 @@
       "resolved": "https://registry.npmjs.org/abstract-random-access/-/abstract-random-access-1.1.2.tgz",
       "integrity": "sha1-mo6sj/eYZvP5tLsUQ8p3jxWYrto=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -23,7 +24,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -35,14 +36,14 @@
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -50,12 +51,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "optional": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -80,8 +75,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "ap": {
@@ -90,28 +85,34 @@
       "integrity": "sha1-2KPyZhU3k5ihtTymzBpmag+/4VA="
     },
     "append-tree": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/append-tree/-/append-tree-2.3.6.tgz",
-      "integrity": "sha512-GVOpyVDH6ynEQykoKN7kXB3uewyZSlcCoBoelffCgBDCSWQTNlTOhnJ85ofxMmsNmGifgAgXVTxs2LP5BOSfhA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/append-tree/-/append-tree-2.4.4.tgz",
+      "integrity": "sha512-rPMUMkR8JjjPDDHHDZ/YeLO0KIbUGCrXgy921F6sBkEXBR9jYYxK8LUlwpZkUVi70cMR6r8uSmHZ/5HvtrntHg==",
       "requires": {
-        "array-lru": "1.1.1",
-        "brfs": "1.4.3",
-        "codecs": "1.2.0",
-        "from2": "2.3.0",
-        "inherits": "2.0.3",
-        "mutexify": "1.2.0",
-        "process-nextick-args": "1.0.7",
-        "protocol-buffers": "3.2.1",
-        "varint": "5.0.0"
+        "array-lru": "^1.1.1",
+        "codecs": "^1.2.0",
+        "from2": "^2.3.0",
+        "inherits": "^2.0.3",
+        "mutexify": "^1.1.0",
+        "process-nextick-args": "^1.0.7",
+        "protocol-buffers-encodings": "^1.1.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        }
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -119,7 +120,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -138,7 +139,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -158,8 +159,8 @@
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.9.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "arrify": {
@@ -169,9 +170,12 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -199,9 +203,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -209,17 +213,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        }
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "balanced-match": {
@@ -228,18 +224,13 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-to-uint8array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64-to-uint8array/-/base64-to-uint8array-1.0.0.tgz",
-      "integrity": "sha512-drjWQcees55+XQSVHYxiUF05Fj6ko3XJUoxykZEXbm0BMmNz2ieWiZGJ+6TFWnjN2saucG6pI13LS92O4kaiAg=="
-    },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bencode": {
@@ -247,7 +238,7 @@
       "resolved": "https://registry.npmjs.org/bencode/-/bencode-1.0.0.tgz",
       "integrity": "sha512-N+VOSP5MkoX+xgnp6Y056iCY5TmCZg9rgPNPQe0bIiXchxYFP4vs/Tf0dTdQ+qQhP7HM2gvfFq+sUVjQsGy5Zw==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "bitfield-rle": {
@@ -255,7 +246,7 @@
       "resolved": "https://registry.npmjs.org/bitfield-rle/-/bitfield-rle-2.1.0.tgz",
       "integrity": "sha1-rinpOCp7pImN6fSLsj/TOMT73Pg=",
       "requires": {
-        "varint": "4.0.1"
+        "varint": "^4.0.0"
       },
       "dependencies": {
         "varint": {
@@ -266,37 +257,47 @@
       }
     },
     "bittorrent-dht": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-7.6.0.tgz",
-      "integrity": "sha512-KinBmIQo4wL742f+4QjMjRHrW6GzDLUeeO+JK5dcGWyOeSKhkPQ7wditN/h0hK88wYjatIAYOC1fEU/WUI3ecw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-7.10.0.tgz",
+      "integrity": "sha512-fvb6M58Ceiv/S94nu6zeaiMoJvUYOeIqRbgaClm+kJTzCAqJPtAR/31pXNYB5iEReOoKqQB5zY33gY0W6ZRWQQ==",
       "requires": {
-        "bencode": "1.0.0",
-        "buffer-equals": "1.0.4",
-        "debug": "2.6.9",
-        "inherits": "2.0.3",
-        "k-bucket": "3.3.0",
-        "k-rpc": "4.1.0",
-        "lru": "3.1.0",
-        "safe-buffer": "5.1.1"
+        "bencode": "^1.0.0",
+        "buffer-equals": "^1.0.3",
+        "debug": "^3.1.0",
+        "inherits": "^2.0.1",
+        "k-bucket": "^3.3.0",
+        "k-rpc": "^4.2.1",
+        "lru": "^3.1.0",
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.0.1",
+        "simple-sha1": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "blake2b": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.2.tgz",
-      "integrity": "sha1-aIDt3KNc/t6SxPsnJCITNPmJFFo=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz",
+      "integrity": "sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==",
       "requires": {
-        "blake2b-wasm": "1.1.4",
-        "nanoassert": "1.1.0"
+        "blake2b-wasm": "^1.1.0",
+        "nanoassert": "^1.0.0"
       }
     },
     "blake2b-wasm": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.4.tgz",
-      "integrity": "sha512-j7ZsvtE8wEXFnyt6TJwNUvBKBOHeNJMQSwIAriQkMcQU5/Ce03Y1kS4W7Sjx6WnhOZi8kVwcrVu9DgUcLHz24A==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
+      "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
       "requires": {
-        "base64-to-uint8array": "1.0.0",
-        "brfs": "1.4.3",
-        "nanoassert": "1.1.0"
+        "nanoassert": "^1.0.0"
       }
     },
     "body": {
@@ -304,24 +305,16 @@
       "resolved": "https://registry.npmjs.org/body/-/body-0.1.0.tgz",
       "integrity": "sha1-5xT+KM2ISKo0zfLJ8kK74uFdHNg=",
       "requires": {
-        "content-types": "0.1.0"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
+        "content-types": "~0.1.0"
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -330,41 +323,39 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
-    "brfs": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz",
-      "integrity": "sha1-22ddb16SPm3wh/ylhZyQkKrtMhY=",
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "quote-stream": "1.0.2",
-        "resolve": "1.4.0",
-        "static-module": "1.5.0",
-        "through2": "2.0.3"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.0.0.tgz",
-      "integrity": "sha1-R0qojzTnvHX6MR0uZFdAnFhGw/4="
-    },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-equals": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
       "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
     },
-    "buffer-indexof": {
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -373,12 +364,13 @@
       "dev": true
     },
     "bulk-write-stream": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.3.tgz",
-      "integrity": "sha1-0pyjhfvVPzV67lvT0wKHMrYq4nU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.4.tgz",
+      "integrity": "sha512-GtKwd/4etuk1hNeprXoESBO1RSeRYJMXKf+O0qHmWdUomLT8ysNEfX/4bZFXr3BK6eukpHiEnhY2uMtEHDM2ng==",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.4"
       }
     },
     "call-me-maybe": {
@@ -392,7 +384,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -412,11 +404,19 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "circular-append-file": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/circular-append-file/-/circular-append-file-1.0.1.tgz",
+      "integrity": "sha512-BUDFvrBTCdeVhg9E05PX4XgMegk6xWB69uGwyuATEg7PMfa9lGU1mzFSK0xWNW2O0i9CAQHN0oIdXI/kI2hPkg==",
+      "requires": {
+        "multistream": "^2.1.0"
       }
     },
     "circular-json": {
@@ -431,7 +431,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -452,16 +452,16 @@
       "dev": true
     },
     "codecs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/codecs/-/codecs-1.2.0.tgz",
-      "integrity": "sha1-UUhUnj0VbF+gU9fLtBlxWgz0PRY="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-1.2.1.tgz",
+      "integrity": "sha512-SPnx+ZHXVJ0qTInRXmnxuyu8PDvSzvop5MXp1BOr/urFQI3yL2n5ewE755skTklF/hKVlWj8cinGxdR2gvLvTA=="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
@@ -471,13 +471,14 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "connections": {
@@ -496,7 +497,7 @@
       "resolved": "https://registry.npmjs.org/content-types/-/content-types-0.1.0.tgz",
       "integrity": "sha1-DnkLOr/vkPbst3roWF25CZyvdXg=",
       "requires": {
-        "iterators": "0.1.0"
+        "iterators": "~0.1.0"
       }
     },
     "core-util-is": {
@@ -509,25 +510,26 @@
       "resolved": "https://registry.npmjs.org/corsify/-/corsify-2.1.0.tgz",
       "integrity": "sha1-EaRbxHqzDFTQC7hp6hgC+82aCdA=",
       "requires": {
-        "http-methods": "0.1.0"
+        "http-methods": "~0.1.0"
       }
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+    "cross-zip": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/cross-zip/-/cross-zip-2.1.5.tgz",
+      "integrity": "sha1-xdGgaksaEqAzBk+UbrWubUvc8+E=",
+      "dev": true,
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
+        "rimraf": "^2.5.2"
+      }
+    },
+    "cross-zip-cli": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cross-zip-cli/-/cross-zip-cli-1.0.0.tgz",
+      "integrity": "sha1-loJvgpPo+x6rD1Y9a6ywDc42jPo=",
+      "dev": true,
+      "requires": {
+        "cross-zip": "^2.1.3",
+        "minimist": "^1.2.0"
       }
     },
     "d": {
@@ -536,7 +538,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.31"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -544,7 +546,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "dat-dns": {
@@ -552,98 +554,171 @@
       "resolved": "https://registry.npmjs.org/dat-dns/-/dat-dns-1.3.2.tgz",
       "integrity": "sha512-Tbk9UacyHcnxWXOeU3UHYkMfnH5VyxcuKXLFjZcUddRqOO4aTA5MV4l3mLmYNnb8TXvsG7ED+7rhfVtFiTXlPQ==",
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9"
+        "call-me-maybe": "^1.0.1",
+        "concat-stream": "^1.6.0",
+        "debug": "^2.6.1"
       }
     },
     "dat-encoding": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/dat-encoding/-/dat-encoding-4.0.2.tgz",
-      "integrity": "sha1-sBBo/g0IDz0+SYWgxK0ht8FGdfY=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dat-encoding/-/dat-encoding-5.0.1.tgz",
+      "integrity": "sha512-PET9PlGt6ejgqU07hbPLx3tP2siDMMFumUe+xwmm4+5W+0cOlpzreCPoMVUBzxWeR4sPdxL+AS53odQTBtzEqA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "dat-ignore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.0.0.tgz",
-      "integrity": "sha512-aPYJYMymfBrkF62wFBVej8p4mbPOB0Z+A5jwHarTMNeq7wYHtSKHoXrmOeUzWdSTtK09+JMuu4+FHfSzY1d0dA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.1.1.tgz",
+      "integrity": "sha512-jRCfWtLh+wtbqJMuge+wZV/2kSL1TKMRWXFgUaT7r0O1OnChKUDG4wqLJo4SjzJjXo7f3V8CVN/u5wYltgSd1Q==",
       "requires": {
-        "anymatch": "1.3.2",
-        "xtend": "4.0.1"
+        "anymatch": "^1.3.0",
+        "xtend": "^4.0.1"
       }
     },
     "dat-link-resolve": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/dat-link-resolve/-/dat-link-resolve-1.1.1.tgz",
-      "integrity": "sha512-xwzZ9/8j+Pn8td4NKYRTafchQxJWKvr/0BLnEmCI8DwyqhCsFtwzhHBLHKXWK761+nm2hElu+xYfkA8ym9c81A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dat-link-resolve/-/dat-link-resolve-2.2.0.tgz",
+      "integrity": "sha512-cu6Fwapm34myc5um6jdQBrtDkjx28oVkOVHbaV4YNLdxrRqUm+FlWuIqFk7zaCZDoZg5TMlCG1SF0j3AFbiOYA==",
       "requires": {
-        "dat-dns": "1.3.2",
-        "dat-encoding": "4.0.2",
-        "debug": "2.6.9",
-        "nets": "3.2.0"
+        "dat-dns": "^3.0.1",
+        "dat-encoding": "^5.0.1",
+        "debug": "^3.1.0",
+        "nets": "^3.2.0"
+      },
+      "dependencies": {
+        "dat-dns": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/dat-dns/-/dat-dns-3.0.2.tgz",
+          "integrity": "sha512-TqkWQ03NvdLK9Rm9n11UCy59KnIsu82A0lPQYcMG02pYTU4xTxShzDryGO2orvmcT5063olmI1R9vKil0jw0Lw==",
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "concat-stream": "^1.6.0",
+            "debug": "^2.6.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "dat-node": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/dat-node/-/dat-node-3.5.3.tgz",
-      "integrity": "sha512-NFZqdd4Fnlv+SYCblpn7SC0XW00PI9dfKOvPsGUsJ6FP4J+MmM+FVAEzLeIQEOj7m477ga/WM6LYSHtGnrUiNA==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/dat-node/-/dat-node-3.5.12.tgz",
+      "integrity": "sha512-XYxdkeNYk8gM6nb125XrOQKAXLZlICLYZUk7bZAktpQUrSjAQnc9qPY2a/KCvHSbdoJf//PwyB00K0UiBTqawQ==",
       "requires": {
-        "dat-ignore": "2.0.0",
-        "dat-link-resolve": "1.1.1",
-        "dat-storage": "1.0.3",
-        "dat-swarm-defaults": "1.0.0",
-        "debug": "2.6.9",
-        "discovery-swarm": "4.4.2",
-        "hyperdrive": "9.9.1",
-        "hyperdrive-http": "4.2.2",
-        "hyperdrive-network-speed": "2.0.1",
-        "mirror-folder": "2.1.1",
-        "multicb": "1.2.2",
-        "random-access-file": "1.8.1",
-        "random-access-memory": "2.4.0",
-        "speedometer": "1.0.0",
-        "stream-each": "1.2.2",
-        "untildify": "3.0.2",
-        "xtend": "4.0.1"
+        "dat-ignore": "^2.1.1",
+        "dat-link-resolve": "^2.2.0",
+        "dat-storage": "^1.0.0",
+        "dat-swarm-defaults": "^1.0.0",
+        "debug": "^3.1.0",
+        "discovery-swarm": "^5.1.2",
+        "hyperdrive": "^9.14.0",
+        "hyperdrive-http": "^4.3.3",
+        "hyperdrive-network-speed": "^2.1.0",
+        "mirror-folder": "^3.0.0",
+        "multicb": "^1.2.1",
+        "random-access-file": "^2.0.1",
+        "random-access-memory": "^3.0.0",
+        "sparse-bitfield": "^3.0.3",
+        "speedometer": "^1.1.0",
+        "stream-each": "^1.2.3",
+        "untildify": "^3.0.2",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "dat-secret-storage": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dat-secret-storage/-/dat-secret-storage-4.0.0.tgz",
-      "integrity": "sha1-AbIZpbwWGe/A9YEio8bOux64tAo=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/dat-secret-storage/-/dat-secret-storage-4.0.1.tgz",
+      "integrity": "sha512-BUhemnKpXUhKNl/1DuUwfFUyjzomlNF940uHPsOa3okmYu9z6mrp/EGQsLO3lO0YQomDUqS0G0DmHTse9vTU1A==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "random-access-file": "1.8.1"
+        "os-homedir": "^1.0.2",
+        "random-access-file": "^2.0.1"
       }
     },
     "dat-storage": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dat-storage/-/dat-storage-1.0.3.tgz",
-      "integrity": "sha512-6qTeWDLCbn4DG5NmTSnCAikivjXXn5ukMLafEbqBn/15zcqdpNgsOx/QnCqXdDoAeP1WWXjJp3GBDtls/et3bA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dat-storage/-/dat-storage-1.0.4.tgz",
+      "integrity": "sha512-THxtCBzrt+AJzhGxXedlxLYeW+AVi5eFLi9Ke9JQ7fTA/j84m1Ci7KPuZ1q44Um/BeIYZ3LO01FWS2MlAOTFRg==",
       "requires": {
-        "append-tree": "2.3.6",
-        "dat-secret-storage": "4.0.0",
-        "hyperdrive": "9.9.1",
-        "multi-random-access": "2.1.1",
-        "random-access-file": "1.8.1"
+        "append-tree": "^2.0.5",
+        "dat-secret-storage": "^4.0.0",
+        "hyperdrive": "^9.1.1",
+        "multi-random-access": "^2.0.3",
+        "random-access-file": "^2.0.1"
       }
     },
     "dat-swarm-defaults": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.0.tgz",
-      "integrity": "sha1-un1YwwnPYMOSSvrYabdRkrYf41Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.1.tgz",
+      "integrity": "sha512-T2WlO7BVmN9USchefsP8entQiByIlJLGuzHLL9qEqOBkyKB8p0Y7XPWxP8dcL43+SkeoxU5NVe7O0bsi3xL8Jg==",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.1"
       }
     },
-    "datland-swarm-defaults": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/datland-swarm-defaults/-/datland-swarm-defaults-1.0.2.tgz",
-      "integrity": "sha1-J3uJWjnxqn+WpJWgL7NmKl7Z8uA=",
+    "datcat": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/datcat/-/datcat-1.2.0.tgz",
+      "integrity": "sha512-d8R8AXgXHpxDS4rPJqqwPiiWNX+ZSI3KrrfOs4eksz2COdlYzkcjLpNGbgmYs3vw3oWLMaAgSh8YzxohlWER0g==",
       "requires": {
-        "xtend": "4.0.1"
+        "append-tree": "^2.4.1",
+        "dat-swarm-defaults": "^1.0.1",
+        "discovery-swarm": "^5.1.1",
+        "duplexify": "^3.5.4",
+        "hypercore": "^6.13.0",
+        "hyperdrive": "^9.12.3",
+        "pump": "^3.0.0",
+        "random-access-memory": "^2.4.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "random-access-memory": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-2.4.0.tgz",
+          "integrity": "sha1-cvPYZbS1WiWYeUc+L7LeNWnGnuI=",
+          "requires": {
+            "process-nextick-args": "^1.0.7"
+          }
+        }
       }
     },
     "debug": {
@@ -672,22 +747,22 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "deglob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
-      "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
+      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
       "dev": true,
       "requires": {
-        "find-root": "1.1.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.5",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.6",
-        "uniq": "1.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
       }
     },
     "del": {
@@ -696,13 +771,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -716,15 +791,16 @@
       "integrity": "sha1-TVr8UYftumfsarDlX2QioOLLczg="
     },
     "discovery-channel": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.4.6.tgz",
-      "integrity": "sha1-Gw8l5YEkUH6GG23D7LdENmu1PK0=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.5.1.tgz",
+      "integrity": "sha512-EEmZQFE0PiOsJj7G3KVCwFGbYs4QchUvzA91iHtZ6HfkIqfBEDSTGLygJrUlY1Tr77WDV+qZVrZuNghHxSL/vw==",
       "requires": {
-        "bittorrent-dht": "7.6.0",
-        "debug": "2.6.9",
-        "dns-discovery": "5.6.1",
-        "pretty-hash": "1.0.1",
-        "thunky": "0.1.0"
+        "bittorrent-dht": "^7.10.0",
+        "buffer-from": "^1.0.0",
+        "debug": "^2.6.9",
+        "dns-discovery": "^6.0.1",
+        "pretty-hash": "^1.0.1",
+        "thunky": "^0.1.0"
       },
       "dependencies": {
         "thunky": {
@@ -735,33 +811,54 @@
       }
     },
     "discovery-swarm": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-4.4.2.tgz",
-      "integrity": "sha1-XTFgpGAZ5Q6HQZV2XffWAe5VqBM=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-5.1.2.tgz",
+      "integrity": "sha512-aqNdl4l76PFb301I1hXkHZSakQTOXR0yRbfDtF7XrZKk+9V5gMQBbQ2xPgnQPfDVG0IeErxkQkoWqp4f9EJe5w==",
       "requires": {
-        "buffer-equals": "1.0.4",
-        "connections": "1.4.2",
-        "debug": "2.6.9",
-        "discovery-channel": "5.4.6",
-        "length-prefixed-message": "3.0.3",
-        "pump": "1.0.2",
-        "to-buffer": "1.1.0",
-        "utp-native": "1.5.4"
+        "buffer-equals": "^1.0.3",
+        "connections": "^1.4.2",
+        "debug": "^3.1.0",
+        "discovery-channel": "^5.5.1",
+        "length-prefixed-message": "^3.0.3",
+        "pump": "^3.0.0",
+        "to-buffer": "^1.0.1",
+        "utp-native": "^1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "dns-discovery": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/dns-discovery/-/dns-discovery-5.6.1.tgz",
-      "integrity": "sha512-r27fv3lDuZXCqmb5b04tV2aDxVbwVJaSyPzwPlOYCUbk9F7JvsY+n7EBfY2Z952bGx5TZt3SLQ+ELFjfqyLVoA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.1.0.tgz",
+      "integrity": "sha512-Kl2tL2zuNR1w6SnsoRaqrOFm7gGP3/i/HzRXtyVBqaOq/5L1D2TUdViUAZ8e/NDbt+jQCJFWoaKCnmDC343usQ==",
       "requires": {
-        "debug": "2.6.9",
-        "dns-socket": "1.6.2",
-        "dns-txt": "2.0.2",
-        "lru": "2.0.1",
-        "minimist": "1.2.0",
-        "multicast-dns": "6.1.1",
-        "network-address": "1.1.2",
-        "unordered-set": "1.1.0"
+        "circular-append-file": "^1.0.1",
+        "debug": "^2.6.9",
+        "dns-socket": "^3.0.0",
+        "lru": "^2.0.0",
+        "minimist": "^1.2.0",
+        "multicast-dns": "^7.0.0",
+        "network-address": "^1.1.2",
+        "pump": "^3.0.0",
+        "speedometer": "^1.0.0",
+        "unordered-set": "^1.1.0"
       },
       "dependencies": {
         "lru": {
@@ -769,7 +866,16 @@
           "resolved": "https://registry.npmjs.org/lru/-/lru-2.0.1.tgz",
           "integrity": "sha1-+XmHHhYuP1yiVL5GhExT1MU2RUQ=",
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "^2.0.1"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "unordered-set": {
@@ -780,46 +886,29 @@
       }
     },
     "dns-packet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
-      "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "dns-socket": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.2.tgz",
-      "integrity": "sha512-Ztbaf5fToBfm/4+sVEJi7mT2mJOLYYpI+TpgOhxwp5l28UwunTpHMccVhTe9L0F6pQ2cUF0ja9ukuTCtzYq2Ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz",
+      "integrity": "sha512-M0WkByoJ/mTm+HtwBQLsRJPe5uGIC/lYVOp+s6ZzhbZ5iq4GxjFyxYPQhB85dgCLvVb43aJQXHDC9aUgyKGc/Q==",
       "requires": {
-        "dns-packet": "1.2.2"
-      }
-    },
-    "dns-txt": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-      "requires": {
-        "buffer-indexof": "1.1.1"
+        "dns-packet": "^4.1.0"
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
-      },
-      "dependencies": {
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        }
+        "esutils": "^2.0.2"
       }
     },
     "dom-walk": {
@@ -832,85 +921,55 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -919,30 +978,31 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.31.tgz",
-      "integrity": "sha1-e7k4yVp/G59ygJLcCcQe3MOY7v4=",
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.31",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -951,12 +1011,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.31",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -965,11 +1025,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.31",
-        "es6-iterator": "2.0.1",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -978,8 +1038,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.31"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -988,10 +1048,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.31",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1000,35 +1060,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-      "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
-      "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
-      }
-    },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        }
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -1037,55 +1078,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        }
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       }
     },
     "eslint-config-standard": {
@@ -1106,19 +1133,19 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "object-assign": "4.1.1",
-        "resolve": "1.4.0"
+        "debug": "^2.2.0",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -1127,16 +1154,16 @@
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.2.3",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "pkg-up": "1.0.0"
+        "eslint-import-resolver-node": "^0.2.0",
+        "eslint-module-utils": "^2.0.0",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "pkg-up": "^1.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -1145,15 +1172,9 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
         }
       }
     },
@@ -1163,10 +1184,10 @@
       "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.5",
-        "minimatch": "3.0.4",
-        "object-assign": "4.1.1",
-        "resolve": "1.4.0",
+        "ignore": "^3.0.11",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.7",
         "semver": "5.3.0"
       }
     },
@@ -1182,11 +1203,11 @@
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "2.0.4",
-        "doctrine": "1.5.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.0.4"
+        "array.prototype.find": "^2.0.1",
+        "doctrine": "^1.2.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.3.4",
+        "object.assign": "^4.0.4"
       },
       "dependencies": {
         "doctrine": {
@@ -1195,15 +1216,9 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
         }
       }
     },
@@ -1214,64 +1229,50 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-      "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        }
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        }
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-      "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-      "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -1279,8 +1280,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.31"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "exit-hook": {
@@ -1294,7 +1295,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1302,20 +1303,20 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -1323,28 +1324,15 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
-    "falafel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
-      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
-      "requires": {
-        "acorn": "5.1.2",
-        "foreach": "2.0.5",
-        "isarray": "0.0.1",
-        "object-keys": "1.0.11"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        }
-      }
-    },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1357,7 +1345,7 @@
       "resolved": "https://registry.npmjs.org/fd-read-stream/-/fd-read-stream-1.1.0.tgz",
       "integrity": "sha1-0wPMv+4CqaVqNJP7CLy1lpGqU7E=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.2.6"
       }
     },
     "figures": {
@@ -1366,8 +1354,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -1376,8 +1364,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -1386,15 +1374,15 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-root": {
@@ -1409,8 +1397,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -1419,10 +1407,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flat-tree": {
@@ -1431,11 +1419,11 @@
       "integrity": "sha1-/KMM3bkAb7ZW6168ea6ydOf96e0="
     },
     "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-function": "1.0.1"
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -1448,13 +1436,14 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1462,13 +1451,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "from2": {
@@ -1476,8 +1465,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -1489,19 +1478,22 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -1515,7 +1507,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1524,12 +1516,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -1537,8 +1529,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -1546,7 +1538,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global": {
@@ -1554,8 +1546,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "globals": {
@@ -1570,12 +1562,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -1590,20 +1582,21 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "5.2.3",
-        "har-schema": "2.0.0"
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -1612,32 +1605,22 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.0.2"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "http-methods": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-methods/-/http-methods-0.1.0.tgz",
       "integrity": "sha1-KWkbb8WPT36Bo2BdyoJoKwaORDA=",
       "requires": {
-        "body": "0.1.0",
-        "content-types": "0.1.0"
+        "body": "~0.1.0",
+        "content-types": "~0.1.0"
       }
     },
     "http-signature": {
@@ -1645,115 +1628,212 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "hypercore": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.10.1.tgz",
-      "integrity": "sha512-aGwPsS+PjbPj7gUctTNDfdtH1T8tzRvt1eX3JAQBiYIELObnJxIH7xpayceef5MZyRu5h8i1njNvV1HPjCRzsQ==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.18.1.tgz",
+      "integrity": "sha512-pH2t3ehdTfe/FFrwVq+6w7L9NoWEnFO9Yxix2kj43vSLMHTWCUFdOCJ9/MaOUAG4OeYy4tiT4+IE5NP0bff6Mg==",
       "requires": {
-        "array-lru": "1.1.1",
-        "atomic-batcher": "1.0.2",
-        "bitfield-rle": "2.1.0",
-        "buffer-equals": "1.0.4",
-        "bulk-write-stream": "1.1.3",
-        "codecs": "1.2.0",
-        "flat-tree": "1.6.0",
-        "from2": "2.3.0",
-        "hypercore-protocol": "6.4.0",
-        "inherits": "2.0.3",
-        "last-one-wins": "1.0.4",
-        "memory-pager": "1.0.3",
-        "merkle-tree-stream": "3.0.3",
-        "process-nextick-args": "1.0.7",
-        "random-access-file": "1.8.1",
-        "sodium-universal": "1.4.0",
-        "sparse-bitfield": "3.0.3",
-        "thunky": "1.0.2",
-        "uint64be": "2.0.1",
-        "unordered-array-remove": "1.0.2",
-        "unordered-set": "2.0.0"
+        "array-lru": "^1.1.0",
+        "atomic-batcher": "^1.0.2",
+        "bitfield-rle": "^2.0.0",
+        "buffer-alloc-unsafe": "^1.0.0",
+        "buffer-equals": "^1.0.4",
+        "buffer-from": "^1.0.0",
+        "bulk-write-stream": "^1.1.3",
+        "codecs": "^1.2.0",
+        "flat-tree": "^1.6.0",
+        "from2": "^2.3.0",
+        "hypercore-crypto": "^1.0.0",
+        "hypercore-protocol": "^6.4.1",
+        "inherits": "^2.0.3",
+        "inspect-custom-symbol": "^1.1.0",
+        "last-one-wins": "^1.0.4",
+        "memory-pager": "^1.0.2",
+        "merkle-tree-stream": "^3.0.3",
+        "pretty-hash": "^1.0.1",
+        "process-nextick-args": "^1.0.7",
+        "random-access-file": "^2.0.1",
+        "sodium-universal": "^2.0.0",
+        "sparse-bitfield": "^3.0.0",
+        "thunky": "^1.0.1",
+        "uint64be": "^2.0.1",
+        "unordered-array-remove": "^1.0.2",
+        "unordered-set": "^2.0.0"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        }
       }
     },
     "hypercore-archiver": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/hypercore-archiver/-/hypercore-archiver-4.1.3.tgz",
-      "integrity": "sha512-5NgRDl7Wk/eA1O6yEkKOYgxpG9t3X4esOwmRnzMNrdDXmwf2N6ZVGnxDLMP9nN6wWlF20a/JBJNLUrykLQd6TQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/hypercore-archiver/-/hypercore-archiver-4.6.0.tgz",
+      "integrity": "sha512-tt8S2ekQu8FPkreoveExWeyaOOjlb9igsFICMYQjnq86R+PavBAsNogIMi/xKcZqRWzDGVyN+QBAG+0T8yajKQ==",
       "requires": {
-        "datland-swarm-defaults": "1.0.2",
-        "debug": "2.6.9",
-        "discovery-swarm": "4.4.2",
-        "hypercore": "6.10.1",
-        "hypercore-protocol": "6.4.0",
-        "random-access-file": "1.8.1",
-        "thunky": "1.0.2",
-        "to-buffer": "1.1.0",
-        "xtend": "4.0.1"
+        "dat-swarm-defaults": "^1.0.1",
+        "datcat": "^1.1.0",
+        "debug": "^2.6.8",
+        "discovery-swarm": "^4.3.7",
+        "hypercore": "^6.6.3",
+        "hypercore-protocol": "^6.4.0",
+        "pump": "^3.0.0",
+        "random-access-file": "^1.8.1",
+        "through2": "^2.0.3",
+        "thunky": "^1.0.2",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "discovery-swarm": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-4.4.2.tgz",
+          "integrity": "sha1-XTFgpGAZ5Q6HQZV2XffWAe5VqBM=",
+          "requires": {
+            "buffer-equals": "^1.0.3",
+            "connections": "^1.4.2",
+            "debug": "^2.4.5",
+            "discovery-channel": "^5.3.0",
+            "length-prefixed-message": "^3.0.3",
+            "pump": "^1.0.1",
+            "to-buffer": "^1.0.1",
+            "utp-native": "^1.2.2"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+              "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "random-access-file": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-1.8.1.tgz",
+          "integrity": "sha512-+Uhk0Of+dWHWjpbL2hizcwSV1UomcN3S0iUGV6BTZ2Js1BP9jHx3E5CT7y0eLbqTQNkVi4iehkHmia7Mdqa47w==",
+          "requires": {
+            "buffer-alloc-unsafe": "^1.0.0",
+            "debug": "^2.5.2",
+            "inherits": "^2.0.1",
+            "mkdirp": "^0.5.1",
+            "thunky": "^1.0.1"
+          }
+        }
+      }
+    },
+    "hypercore-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz",
+      "integrity": "sha512-xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-from": "^1.1.0",
+        "sodium-universal": "^2.0.0",
+        "uint64be": "^2.0.2"
       }
     },
     "hypercore-protocol": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.4.0.tgz",
-      "integrity": "sha1-iXpvoLeSa0iZXdp+A9qtB31jODg=",
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.6.4.tgz",
+      "integrity": "sha512-9TU7P+uve0e5v1ZiBx70DFhkpepW4iNSGYlZthK+Unm0EbZ+Yppc6clH7JTffPBNUMSnDrE552MfXMilpCHZMw==",
       "requires": {
-        "brfs": "1.4.3",
-        "inherits": "2.0.3",
-        "protocol-buffers": "3.2.1",
-        "readable-stream": "2.3.3",
-        "sodium-universal": "1.4.0",
-        "sorted-indexof": "1.0.0",
-        "varint": "5.0.0"
+        "buffer-alloc-unsafe": "^1.0.0",
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "protocol-buffers-encodings": "^1.1.0",
+        "readable-stream": "^2.2.6",
+        "sodium-universal": "^2.0.0",
+        "sorted-indexof": "^1.0.0",
+        "varint": "^5.0.0"
       }
     },
     "hyperdrive": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.9.1.tgz",
-      "integrity": "sha512-7MHcxf3zrZpXCTlo9dAKcdcRKQI7SsWi14A6d5s/m5N/81swz4z/WH+Ed1akmZtujoKrrXJkzZt90zhnVPuB1Q==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.14.0.tgz",
+      "integrity": "sha512-LTgbsJ+9ZrdQfLaXXc01kQMttaicHhSOtUM3v/k7ORwXJziqQ2eMQ80+8Tfg67ja+w6zrdl5HYOK+mnlwQpCww==",
       "requires": {
-        "append-tree": "2.3.6",
-        "duplexify": "3.5.1",
-        "from2": "2.3.0",
-        "hypercore": "6.10.1",
-        "inherits": "2.0.3",
-        "mutexify": "1.2.0",
-        "protocol-buffers": "3.2.1",
-        "random-access-file": "1.8.1",
-        "sodium-universal": "1.4.0",
-        "stream-collector": "1.0.1",
-        "stream-each": "1.2.2",
-        "thunky": "1.0.2",
-        "uint64be": "2.0.1",
-        "unixify": "1.0.0"
+        "append-tree": "^2.3.5",
+        "duplexify": "^3.5.0",
+        "from2": "^2.3.0",
+        "hypercore": "^6.10.4",
+        "inherits": "^2.0.3",
+        "mutexify": "^1.1.0",
+        "protocol-buffers-encodings": "^1.1.0",
+        "random-access-file": "^2.0.1",
+        "sodium-universal": "^2.0.0",
+        "stream-collector": "^1.0.1",
+        "stream-each": "^1.2.0",
+        "thunky": "^1.0.2",
+        "uint64be": "^2.0.1",
+        "unixify": "^1.0.0"
       }
     },
     "hyperdrive-http": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/hyperdrive-http/-/hyperdrive-http-4.2.2.tgz",
-      "integrity": "sha512-NgfZGxfQoYIEIuYat+dki/GAWpjmM/X+5YL5faTrX3VgXdGObVOhKEHQISk855T8C+R4aPP8QpF1YR8adUVBNw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/hyperdrive-http/-/hyperdrive-http-4.3.3.tgz",
+      "integrity": "sha512-YRAjbCCRefLK9EMcgDXRgDx/sZksWf85iLtGl9JMVrzFSIfUx0//DpUJ6k0m0eG4KHJJM+dBwORxFPNi29EQHg==",
       "requires": {
-        "corsify": "2.1.0",
-        "directory-index-html": "2.1.0",
-        "mime": "1.4.1",
-        "pump": "1.0.2",
-        "range-parser": "1.2.0"
+        "corsify": "^2.1.0",
+        "directory-index-html": "^2.1.0",
+        "mime": "^2.3.1",
+        "pump": "^3.0.0",
+        "range-parser": "^1.2.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "hyperdrive-network-speed": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hyperdrive-network-speed/-/hyperdrive-network-speed-2.0.1.tgz",
-      "integrity": "sha1-QNr4LjG511Pyrm368IGGYe0k/hU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive-network-speed/-/hyperdrive-network-speed-2.1.0.tgz",
+      "integrity": "sha512-JolPS374h6oS1rmz1iebFfeDDvA2nAtiHbx9VJJGMgSDSx4Q77eeY09hDgZwY7KatSKUGWnnSyydSgVUb3+8Lw==",
       "requires": {
-        "debug": "2.6.9",
-        "speedometer": "1.0.0"
+        "debug": "^3.1.0",
+        "speedometer": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -1768,8 +1848,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1777,31 +1857,42 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "optional": true
+    },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
+    "inspect-custom-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/inspect-custom-symbol/-/inspect-custom-symbol-1.1.0.tgz",
+      "integrity": "sha512-vtI2YXBRZBkU6DlfHfd0GtZENfiEiTacAXUd0ZY6HA+X7aPznpFfPmzSC+tHKXAkz9KDSdI4AYfwAMXR5t+isg=="
+    },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "ip": {
@@ -1816,15 +1907,14 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -1842,7 +1932,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -1861,7 +1951,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -1874,19 +1964,26 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -1894,8 +1991,13 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
+    },
+    "is-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz",
+      "integrity": "sha512-2Xj8sA0zDrAcaoWfBiNmc6VPWAgKDpim0T3J9Djq7vbm1UjwbUWzeuLu/FwC46g3cBbAn0E5R0xwVtOobM6Xxg=="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1904,21 +2006,21 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -1934,7 +2036,8 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -1942,17 +2045,14 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -1988,7 +2088,7 @@
       "resolved": "https://registry.npmjs.org/iterators/-/iterators-0.1.0.tgz",
       "integrity": "sha1-0D9mbKTmEwE4VlmXys6lQWQgMVY=",
       "requires": {
-        "ap": "0.1.0"
+        "ap": "~0.1.0"
       }
     },
     "js-tokens": {
@@ -1998,21 +2098,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        }
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -2020,6 +2112,12 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2035,8 +2133,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -2047,7 +2146,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -2073,33 +2173,56 @@
       "dev": true
     },
     "k-bucket": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.0.tgz",
-      "integrity": "sha512-WIAQ54LfNjzt4viUIEVnXo9cr7ALS9Yocg+USLoiO89Uvbf9hz0OBtqmfzSr49kT3vbnhlzFfsJHFQ0xnp7LbA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz",
+      "integrity": "sha512-kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==",
       "requires": {
-        "buffer-equals": "1.0.4",
-        "inherits": "2.0.3",
-        "randombytes": "2.0.5"
+        "buffer-equals": "^1.0.3",
+        "inherits": "^2.0.1",
+        "randombytes": "^2.0.3"
       }
     },
     "k-rpc": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-4.1.0.tgz",
-      "integrity": "sha512-Qvetvl34ZXrOWDXMMeP/WQMN3/ep3SASGxcJhUZLgQb1U7VA+/SzwxhDi9KRZWBEqrU0FUWr/yqLP44TfzSwzw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-4.3.1.tgz",
+      "integrity": "sha512-mgAJZeFYbpP0xzJzmS0TQTYoFI0sjy3GnKFhg8wyboL+KvWg2WLaA2Oy9PthLPx2Rxz4WeBMk4y3MSOrDJ95FA==",
       "requires": {
-        "buffer-equals": "1.0.4",
-        "k-bucket": "3.3.0",
-        "k-rpc-socket": "1.7.1",
-        "safe-buffer": "5.1.1"
+        "buffer-equals": "^1.0.3",
+        "k-bucket": "^4.0.0",
+        "k-rpc-socket": "^1.7.2",
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "k-bucket": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
+          "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "randombytes": "^2.0.3"
+          }
+        }
       }
     },
     "k-rpc-socket": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.7.1.tgz",
-      "integrity": "sha512-FmHDmrT6sIs2MM/uMYW0Jmjd01wk2NxzPd6+9iH7onvutqhWXZ8PoZ9p/mVS58SQILC7jKZacC72V5QNkvAXew==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.8.0.tgz",
+      "integrity": "sha512-f/9TynsO8YYjZ6JjNNtSSH7CJcIHcio1buy3zqByGxb/GX8AWLdL6FZEWTrN8V3/J7W4/E0ZTQQ+Jt2rVq7ELg==",
       "requires": {
-        "bencode": "1.0.0",
-        "safe-buffer": "5.1.1"
+        "bencode": "^2.0.0",
+        "buffer-equals": "^1.0.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "bencode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.0.tgz",
+          "integrity": "sha512-wr2HwwrUpfB5c68zmAudOltC7rZ1G0+lQOcnuEcfIM3AWAVnB3rHI3nlgd/2CWTfQ3w3zagKt89zni/M+VLZ8g==",
+          "requires": {
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "kind-of": {
@@ -2107,7 +2230,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "last-one-wins": {
@@ -2120,7 +2243,7 @@
       "resolved": "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.3.tgz",
       "integrity": "sha1-JFR01pq8BhTco2jcNaqAdJgqI6w=",
       "requires": {
-        "varint": "3.0.1"
+        "varint": "^3.0.1"
       },
       "dependencies": {
         "varint": {
@@ -2136,20 +2259,28 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -2158,8 +2289,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -2171,9 +2302,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash.cond": {
@@ -2187,21 +2318,26 @@
       "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
       "integrity": "sha1-6n+4VG2DczOWoTCR12z+tMBoN9U=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
     "memory-pager": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.0.3.tgz",
-      "integrity": "sha1-A3gSAD5mq+3MhMynIsQlWQ6Pqog="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
+      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg=="
     },
     "merkle-tree-stream": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-3.0.3.tgz",
       "integrity": "sha1-+KBkdg0355eK1fn208EZpJT1cIE=",
       "requires": {
-        "flat-tree": "1.6.0",
-        "readable-stream": "2.3.3"
+        "flat-tree": "^1.3.0",
+        "readable-stream": "^2.0.5"
       }
     },
     "micromatch": {
@@ -2209,37 +2345,37 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.35.0"
       }
     },
     "min-document": {
@@ -2247,7 +2383,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -2256,7 +2392,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2265,12 +2401,12 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mirror-folder": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mirror-folder/-/mirror-folder-2.1.1.tgz",
-      "integrity": "sha1-GtO3d7OeQDzCe/UghsI+Qe9MlgQ=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mirror-folder/-/mirror-folder-3.0.0.tgz",
+      "integrity": "sha512-fh6wDXcSpFoKY7ZPHnEv1+xjLOS7tlkEpTvl4Y6ZsT0HNjIaYg6ktq9ng8MPthFruunS8D/3GnPeaWhoQD3X9g==",
       "requires": {
-        "fd-read-stream": "1.1.0",
-        "recursive-watch": "1.1.2"
+        "fd-read-stream": "^1.1.0",
+        "recursive-watch": "^1.1.1"
       }
     },
     "mkdirp": {
@@ -2298,31 +2434,33 @@
       "resolved": "https://registry.npmjs.org/multi-random-access/-/multi-random-access-2.1.1.tgz",
       "integrity": "sha1-ZGLxsgQQnMxkRgFlARCoKEQ9ZuI=",
       "requires": {
-        "abstract-random-access": "1.1.2",
-        "inherits": "2.0.3",
-        "sorted-array-functions": "1.0.0"
+        "abstract-random-access": "^1.1.2",
+        "inherits": "^2.0.1",
+        "sorted-array-functions": "^1.0.0"
       }
     },
     "multicast-dns": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
-      "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.1.tgz",
+      "integrity": "sha512-jx8bO2QZvx5oJXWhiuEb6I8XgufpPXvKFSAoSvurD2nECVhbQQTilY33IfChreWqhqPgzKZbpgsyHapjnRTnlw==",
       "requires": {
-        "dns-packet": "1.2.2",
-        "thunky": "0.1.0"
-      },
-      "dependencies": {
-        "thunky": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-          "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
-        }
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
       }
     },
     "multicb": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
       "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
+    },
+    "multistream": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz",
+      "integrity": "sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.5"
+      }
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -2336,9 +2474,9 @@
       "integrity": "sha512-oprzxd2zhfrJqEuB98qc1dRMMonClBQ57UPDjnbcrah4orEMTq1jq3+AcdFe5ePzdbJXI7zmdhfftIdMnhYFoQ=="
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "optional": true
     },
     "nanoassert": {
@@ -2357,8 +2495,8 @@
       "resolved": "https://registry.npmjs.org/nets/-/nets-3.2.0.tgz",
       "integrity": "sha1-1RH7q3rxHaAT8huX7pF0fTOFLTg=",
       "requires": {
-        "request": "2.83.0",
-        "xhr": "2.4.0"
+        "request": "^2.65.0",
+        "xhr": "^2.1.0"
       }
     },
     "network-address": {
@@ -2366,10 +2504,16 @@
       "resolved": "https://registry.npmjs.org/network-address/-/network-address-1.1.2.tgz",
       "integrity": "sha1-Sqe/1D8D8LgclwKxPWqFjdsybz4="
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
     "node-gyp-build": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-      "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.4.0.tgz",
+      "integrity": "sha512-YoviGBJYGrPdLOKDIQB0sKxuKy/EEsxzooNkOZak4vSTKT/qH0Pa6dj3t1MJjEQGsefih61IyHDmO1WW7xOFfw==",
       "optional": true
     },
     "normalize-path": {
@@ -2377,7 +2521,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "number-is-nan": {
@@ -2387,9 +2531,9 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -2397,25 +2541,22 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
-    "object-inspect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
-    },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
     },
     "object.assign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.omit": {
@@ -2423,8 +2564,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "once": {
@@ -2432,12 +2573,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -2447,12 +2588,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -2461,10 +2602,13 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -2472,18 +2616,24 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-headers": {
@@ -2491,17 +2641,18 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "0.3.2",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "path-exists": {
@@ -2510,7 +2661,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -2526,9 +2677,10 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -2553,17 +2705,17 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-conf": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
-      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "2.0.0"
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -2572,7 +2724,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -2583,9 +2735,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.1.0",
-        "xtend": "4.0.1"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -2594,7 +2746,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pkg-up": {
@@ -2603,7 +2755,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pluralize": {
@@ -2634,9 +2786,9 @@
       "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "1.1.8",
@@ -2644,31 +2796,27 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
-    "protocol-buffers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/protocol-buffers/-/protocol-buffers-3.2.1.tgz",
-      "integrity": "sha1-NyWOF+JKCC8G67F3MekoUdHHaIk=",
+    "protocol-buffers-encodings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.1.0.tgz",
+      "integrity": "sha512-SmjEuAf3hc3h3rWZ6V1YaaQw2MNJWK848gLJgzx/sefOJdNLujKinJVXIS0q2cBQpQn2Q32TinawZyDZPzm4kQ==",
       "requires": {
-        "brfs": "1.4.3",
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "protocol-buffers-schema": "3.3.2",
-        "signed-varint": "2.0.1",
-        "varint": "5.0.0"
+        "signed-varint": "^2.0.1",
+        "varint": "^5.0.0"
       }
     },
-    "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "pump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -2677,83 +2825,65 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-    },
-    "quote-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-      "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
-      "requires": {
-        "buffer-equal": "0.0.1",
-        "minimist": "1.2.0",
-        "through2": "2.0.3"
-      }
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "random-access-file": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-1.8.1.tgz",
-      "integrity": "sha512-+Uhk0Of+dWHWjpbL2hizcwSV1UomcN3S0iUGV6BTZ2Js1BP9jHx3E5CT7y0eLbqTQNkVi4iehkHmia7Mdqa47w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.0.1.tgz",
+      "integrity": "sha512-nb4fClpzoUY+v1SHrro+9yykN90eMA1rc+xM39tnZ5R3BgFY+J/NxPZ0KuUpishEsvnwou9Fvm2wa3cjeuG7vg==",
       "requires": {
-        "buffer-alloc-unsafe": "1.0.0",
-        "debug": "2.6.9",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "thunky": "1.0.2"
+        "mkdirp": "^0.5.1",
+        "random-access-storage": "^1.1.1"
       }
     },
     "random-access-memory": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-2.4.0.tgz",
-      "integrity": "sha1-cvPYZbS1WiWYeUc+L7LeNWnGnuI=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.0.0.tgz",
+      "integrity": "sha512-O/d5C/kTOs/aDix1CD+N7z4SgNVGPx+xpFKXGfrC0TFpqYVrsJEUmQCl3ITTg7FVMoCmLBo5rdkA5FcFg00NTA==",
       "requires": {
-        "process-nextick-args": "1.0.7"
+        "inherits": "^2.0.3",
+        "is-options": "^1.0.1",
+        "random-access-storage": "^1.1.1"
+      }
+    },
+    "random-access-storage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+      "requires": {
+        "inherits": "^2.0.3"
       }
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -2767,17 +2897,17 @@
       "integrity": "sha1-qP4Grc3YtB44B1BMJEpeqmziUkk="
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -2786,8 +2916,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -2797,15 +2927,15 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "^1.1.6"
       }
     },
     "recursive-watch": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.2.tgz",
-      "integrity": "sha1-kS4tYqg8iziNKIxDQ0lfJHvEP44=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz",
+      "integrity": "sha512-fWejAmdLi7B/jipBUjTLnqId+PK+573fbGNbdaNA/AiAnQAx6OYOLCGWRs0W5+PyM1rLzZSWK2f40QpHSR49PQ==",
       "requires": {
-        "ttl": "1.3.0"
+        "ttl": "^1.3.0"
       }
     },
     "regex-cache": {
@@ -2813,7 +2943,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -2832,32 +2962,30 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-uncached": {
@@ -2866,16 +2994,17 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -2890,8 +3019,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -2900,7 +3029,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -2909,14 +3038,19 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-parallel": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
+    },
+    "rusha": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
+      "integrity": "sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo="
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -2925,9 +3059,14 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.3.0",
@@ -2935,20 +3074,15 @@
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true
     },
-    "shallow-copy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
-    },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "signed-varint": {
@@ -2956,17 +3090,23 @@
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
-        "varint": "5.0.0"
+        "varint": "~5.0.0"
+      }
+    },
+    "simple-sha1": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
+      "integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
+      "requires": {
+        "rusha": "^0.8.1"
       }
     },
     "siphash24": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.0.2.tgz",
-      "integrity": "sha512-/yUF5S4+z46QxpT/mW/wdlsQQTdO1yl3H36aql6u2m3Ve6u9iATS+yHN+rMXr4jm1qQ0wJUDK2ofdkZeQjMmig==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz",
+      "integrity": "sha512-dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==",
       "requires": {
-        "base64-to-uint8array": "1.0.0",
-        "brfs": "1.4.3",
-        "nanoassert": "1.1.0"
+        "nanoassert": "^1.0.0"
       }
     },
     "slice-ansi": {
@@ -2975,75 +3115,59 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "sodium-javascript": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.1.tgz",
-      "integrity": "sha512-M8H34jbD8WPaNVx7LfLyk3fabujOppnjEskJYXSlYqJ83BMFyO3wYFzvhSW3/yL4j0JFgYRYm5c/dzGK1AqxFA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.5.tgz",
+      "integrity": "sha512-UMmCHovws/sxIBZsIRhIl8uRPou/RFDD0vVop81T1hG106NLLgqajKKuHAOtAP6hflnZ0UrVA2VFwddTd/NQyA==",
       "requires": {
-        "blake2b": "2.1.2",
-        "nanoassert": "1.1.0",
-        "siphash24": "1.0.2",
-        "xsalsa20": "1.0.2"
+        "blake2b": "^2.1.1",
+        "nanoassert": "^1.0.0",
+        "siphash24": "^1.0.1",
+        "xsalsa20": "^1.0.0"
       }
     },
     "sodium-native": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-1.10.3.tgz",
-      "integrity": "sha512-FIeYaG5cc0YZjsAaWP/BCXDNO2xusbtDJbCbEvXrf6/6+dRo/8XCiEG0kwlRcR0wr56sgsZ327BId3ifFe2WYw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
+      "integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-gyp-build": "3.2.2"
+        "ini": "^1.3.5",
+        "nan": "^2.4.0",
+        "node-gyp-build": "^3.0.0"
       }
     },
     "sodium-universal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-1.4.0.tgz",
-      "integrity": "sha512-hMQ4uoqoyUES9Q8CAeUFYcc2ODq72cq+riSTO+XsuZZjYDTvKlvFIK+v/wMTbv5woa/omMwFvsxib5gVz0qEXg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz",
+      "integrity": "sha512-csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==",
       "requires": {
-        "sodium-javascript": "0.5.1",
-        "sodium-native": "1.10.3"
+        "sodium-javascript": "~0.5.0",
+        "sodium-native": "^2.0.0"
       }
     },
     "sorted-array-functions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.0.0.tgz",
-      "integrity": "sha1-wLVU2ecJr/y+VtNMGyUUGX/Tgnk="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
+      "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg=="
     },
     "sorted-indexof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sorted-indexof/-/sorted-indexof-1.0.0.tgz",
       "integrity": "sha1-F8dC/3zxh+L1mhXfm4HxemLOCJk="
     },
-    "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "optional": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
-    },
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "requires": {
-        "memory-pager": "1.0.3"
+        "memory-pager": "^1.0.2"
       }
     },
     "speedometer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
-      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz",
+      "integrity": "sha512-z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3052,18 +3176,19 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "standard": {
@@ -3072,15 +3197,15 @@
       "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
-        "eslint": "3.19.0",
+        "eslint": "~3.19.0",
         "eslint-config-standard": "10.2.1",
         "eslint-config-standard-jsx": "4.0.2",
-        "eslint-plugin-import": "2.2.0",
-        "eslint-plugin-node": "4.2.3",
-        "eslint-plugin-promise": "3.5.0",
-        "eslint-plugin-react": "6.10.3",
-        "eslint-plugin-standard": "3.0.1",
-        "standard-engine": "7.0.0"
+        "eslint-plugin-import": "~2.2.0",
+        "eslint-plugin-node": "~4.2.2",
+        "eslint-plugin-promise": "~3.5.0",
+        "eslint-plugin-react": "~6.10.0",
+        "eslint-plugin-standard": "~3.0.1",
+        "standard-engine": "~7.0.0"
       }
     },
     "standard-engine": {
@@ -3089,117 +3214,10 @@
       "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
       "dev": true,
       "requires": {
-        "deglob": "2.1.0",
-        "get-stdin": "5.0.1",
-        "minimist": "1.2.0",
-        "pkg-conf": "2.0.0"
-      }
-    },
-    "static-eval": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
-      "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
-      "requires": {
-        "escodegen": "0.0.28"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
-          "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
-          "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.3.2",
-            "source-map": "0.1.43"
-          }
-        },
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-        },
-        "estraverse": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-          "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
-        }
-      }
-    },
-    "static-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
-      "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
-      "requires": {
-        "concat-stream": "1.6.0",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.1",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "quote-stream": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
-          "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
-          "requires": {
-            "minimist": "0.0.8",
-            "through2": "0.4.2"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        }
+        "deglob": "^2.1.0",
+        "get-stdin": "^5.0.1",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^2.0.0"
       }
     },
     "stream-collector": {
@@ -3207,16 +3225,16 @@
       "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
       "integrity": "sha1-TU5V8XE1YSGyxfZVn5RHBaso2xU=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.1"
       }
     },
     "stream-each": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-shift": {
@@ -3224,29 +3242,24 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -3254,7 +3267,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -3281,12 +3294,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -3295,8 +3308,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -3317,8 +3330,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3327,7 +3340,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3349,8 +3362,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "thunky": {
@@ -3359,16 +3372,17 @@
       "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
     },
     "to-buffer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.0.tgz",
-      "integrity": "sha1-N1vAPtrlw1qPoLP+laHzmF2x3Po="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       }
     },
     "trim": {
@@ -3376,23 +3390,17 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
-    },
     "ttl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ttl/-/ttl-1.3.0.tgz",
-      "integrity": "sha1-AK2hwNevCQ0+9HlTIbTw1hK0cKU="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ttl/-/ttl-1.3.1.tgz",
+      "integrity": "sha512-+bGy9iDAqg3WSfc2ZrprToSPJhZjqy7vUv9wupQzsiv+BVPVx1T2a6G4T0290SpQj+56Toaw9BiLO5j5Bd7QzA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -3407,7 +3415,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -3416,14 +3424,17 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uint64be": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.1.tgz",
-      "integrity": "sha1-oxDZTk5eCwKpXWeOMzI/gCvchCg="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz",
+      "integrity": "sha512-9QqdvpGQTXgxthP+lY4e/gIBy+RuqcBaC6JVwT5I3bDLgT/btL6twZMR0pI3/Fgah9G/pdwzIprE5gL6v9UvyQ==",
+      "requires": {
+        "buffer-alloc": "^1.1.0"
+      }
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "uniq": {
       "version": "1.0.1",
@@ -3436,7 +3447,7 @@
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
       "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
       "requires": {
-        "normalize-path": "2.1.1"
+        "normalize-path": "^2.1.1"
       }
     },
     "unordered-array-remove": {
@@ -3445,14 +3456,14 @@
       "integrity": "sha1-xUbo+I4xegzyZEyX7LV9umbSUO8="
     },
     "unordered-set": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.0.tgz",
-      "integrity": "sha1-mFon6XW6oguCY66np5HpMAlBqew="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg=="
     },
     "untildify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-      "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
     },
     "user-home": {
       "version": "2.0.0",
@@ -3460,7 +3471,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -3469,20 +3480,20 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utp-native": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-1.5.4.tgz",
-      "integrity": "sha512-cOzS0kJlMC9LScG9Rl0W6j4y8DimC1ZQQniNwJuUKwnCwuBG3jj3tTYjudTCmEGZoGnYrRTf8MZ0IrTL4hls2w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-1.7.3.tgz",
+      "integrity": "sha512-vRAKaS8WcYNgzbxyH2LdheqgL4sQLis8LXl7r/mN+O4mpWlUpoCsTtietxepLrft2q0TFA2gaIvSWN1iRkzW/w==",
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-gyp-build": "3.2.2",
-        "readable-stream": "2.3.3"
+        "nan": "^2.5.1",
+        "node-gyp-build": "^3.0.0",
+        "readable-stream": "^2.2.2"
       }
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "varint": {
       "version": "5.0.0",
@@ -3494,22 +3505,22 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "websocket-stream": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.0.1.tgz",
-      "integrity": "sha512-N3X0rs/ucnccDdyn5GkwD7HVjtvcE3scSmYzdndzma/3ovQpjUxDRP71nTliph9EpXYt9fXbdCVL+e6JuguC+A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.1.2.tgz",
+      "integrity": "sha512-lchLOk435iDWs0jNuL+hiU14i3ERSrMA0IKSiJh7z6X/i4XNsutBZrtqu2CPOZuA4G/zabiqVAos0vW+S7GEVw==",
       "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "ws": "3.2.0",
-        "xtend": "4.0.1"
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.1",
+        "ws": "^3.2.0",
+        "xtend": "^4.0.0"
       }
     },
     "wordwrap": {
@@ -3529,28 +3540,28 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "ws": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.2.0.tgz",
-      "integrity": "sha512-hTS3mkXm/j85jTQOIcwVz3yK3up9xHgPtgEhDBOH3G18LDOZmSAG1omJeXejLKJakx+okv8vS1sopgs7rw0kVw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.0"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xhr": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-      "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xsalsa20": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,16 @@
     "websocket-stream": "^5.0.1"
   },
   "devDependencies": {
+    "cross-zip-cli": "^1.0.0",
     "standard": "^10.0.3"
   },
   "bin": {
     "subscribed-hypercored": "./index.js"
   },
   "scripts": {
-    "test": "standard"
+    "test": "standard",
+    "package": "rm -rf builds && npm run pkg && ./package.sh",
+    "pkg": "pkg package.json -o builds/hypercored"
   },
   "repository": {
     "type": "git",
@@ -31,5 +34,15 @@
   "bugs": {
     "url": "https://github.com/jimpick/subscribed-hypercored/issues"
   },
-  "homepage": "https://github.com/jimpick/subscribed-hypercored"
+  "homepage": "https://github.com/jimpick/subscribed-hypercored",
+  "pkg": {
+    "assets": [
+      "./node_modules/utp-native/prebuilds/**",
+      "./node_modules/blake2b-wasm/blake2b.wasm",
+      "./node_modules/siphash24/siphash24.wasm"
+    ],
+    "targets": [
+      "node10-linux-x64"
+    ]
+  }
 }

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# couldnt figure out undocumented 'output template' mode for pkg so wrote this
+# also need to include .node files until pkg supports including them in binary
+
+NODE_ABI="node-64"
+VERSION=$(node -pe "require('./package.json').version")
+
+rm -rf dist
+
+mkdir dist
+mkdir builds/hypercored-$VERSION-linux-x64
+
+mv builds/hypercored builds/hypercored-$VERSION-linux-x64/hypercored
+
+cp node_modules/utp-native/prebuilds/linux-x64/$NODE_ABI.node builds/hypercored-$VERSION-linux-x64/
+
+cp LICENSE builds/hypercored-$VERSION-linux-x64/
+
+cp README.md builds/hypercored-$VERSION-linux-x64/README
+
+cd builds
+../node_modules/.bin/cross-zip hypercored-$VERSION-linux-x64 ../dist/hypercored-$VERSION-linux-x64.zip
+
+rm -rf ../builds
+
+# now travis will upload the 3 zips in dist to the release


### PR DESCRIPTION
Use `pkg` to create a binary for easier distribution. We are using this with our decentralized data preservation project =). 

Would also like to add a [download script](https://github.com/datproject/dat/blob/master/download.sh) with install instructions. But need to turn travis on and set that up so they can build the releases. See https://github.com/datproject/dat/blob/master/.travis.yml